### PR TITLE
Adjust default top padding to mimic tab spacing

### DIFF
--- a/app/common/schema.json
+++ b/app/common/schema.json
@@ -458,7 +458,7 @@
               },
               "padding": {
                 "type": "string",
-                "default": "5px 0 10px 15px"
+                "default": "40px 0 10px 15px"
               }
             }
           }


### PR DESCRIPTION
## Feature Enhancements Added
Set the default top padding on the visor to 40px. This pushes the prompt below the window buttons.


## Bugs Fixed
List out Issue Numbers below in a list


## Description of overall changes
Before:
![image](https://user-images.githubusercontent.com/16766681/55497219-e7343500-560e-11e9-9d79-a5d28eab8df0.png)
After:
![image](https://user-images.githubusercontent.com/16766681/55497288-0c28a800-560f-11e9-9d7d-3c12263507b2.png)
