### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ more gifs!
 Use Homebrew Cask to download the app by running the following
 
 ```bash
-❯ brew cask install archipelago
+❯ brew install --cask archipelago
 ```
 
 ### Download Links


### PR DESCRIPTION
## Bugs Fixed

Fix #469 

## Description of overall changes

Use `brew install --cask` instead of `brew cask install`
